### PR TITLE
fix: publishing authkit-node to NPM

### DIFF
--- a/.github/workflows/publish-authkit.yaml
+++ b/.github/workflows/publish-authkit.yaml
@@ -1,11 +1,9 @@
 name: Publish AuthKit Package to NPM
 
 on:
-  release:
-    types: [created]
   push:
-    branches:
-      - npm-publish-fixes
+    tags:
+      - "authkit-node-[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   build:

--- a/.github/workflows/publish-authkit.yaml
+++ b/.github/workflows/publish-authkit.yaml
@@ -3,6 +3,9 @@ name: Publish AuthKit Package to NPM
 on:
   release:
     types: [created]
+  push:
+    branches:
+      - npm-publish-fixes
 
 jobs:
   build:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/connections/package.json
+++ b/packages/connections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@picahq/authkit-node",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Secure token generation for Pica AuthKit",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Drops the `.npmrc` file to fix authentication issues when publishing from GitHub Actions. The NPM token is already being passed to `npm publish` in the GitHub Action workflow, https://github.com/picahq/typescript-services/blob/main/.github/workflows/publish-authkit.yaml#L26

This also changes the workflow to only run when a tag is created with the `authkit-node-` prefix, e.g. `authkit-node-1.0.1`. This allows us to tag backend releases independently from authkit-node releases, which would fail unless the version number gets bumped in `package.json`.